### PR TITLE
fix: clear cached ranking on invalidate_cache()

### DIFF
--- a/lib/elo_router.py
+++ b/lib/elo_router.py
@@ -49,6 +49,7 @@ class ELORouter:
 
     def invalidate_cache(self) -> None:
         """Force a reload on the next call."""
+        self._cached_ranking = []
         self._cache_loaded_at = 0.0
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`invalidate_cache()` only reset `_cache_loaded_at` to `0.0`, but `_is_cache_fresh()` also checks `bool(self._cached_ranking)`. On freshly booted CI runners where `time.monotonic()` is less than `cache_ttl`, the cache was still considered fresh after invalidation — causing `test_invalidate_cache_forces_reload` to fail.

## Fix
Clear `_cached_ranking` in addition to resetting `_cache_loaded_at`, so `_is_cache_fresh()` returns `False` unconditionally after invalidation.